### PR TITLE
Fixes popup collapse on new versions of Chrome.

### DIFF
--- a/popup.html
+++ b/popup.html
@@ -9,7 +9,7 @@
 </head>
 
 <body>
-    <div style="padding: 4px; display: flex; flex-direction: column;">
+    <div style="padding: 4px; display: flex; flex-direction: column; gap: 2px; min-width: 150px;">
         <span style="text-align: center; font-size: medium; font-weight: bold; margin-bottom: 5px;">Coursera Translate
             Extension</span>
         <select id="lang">


### PR DESCRIPTION
After updating chrome, the popup became almost zero width. I fixed this by adding a min-width style to the popup.html. I am attaching a couple of before and after screenshots.
![image 1](https://github.com/mucahit-sahin/coursera-subtitle-translate-extension/assets/110279020/97e5341f-4b41-4d79-8f2d-321d3de33627)
![image 2](https://github.com/mucahit-sahin/coursera-subtitle-translate-extension/assets/110279020/8e4106e9-cf51-4fbc-a7af-e9b5beb709b2)
